### PR TITLE
specify Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source :rubygems
+ruby "1.9.3"
 gem 'sinatra', '1.1.0'
 gem 'thin', '1.2.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,3 +19,9 @@ PLATFORMS
 DEPENDENCIES
   sinatra (= 1.1.0)
   thin (= 1.2.7)
+
+RUBY VERSION
+   ruby 1.9.3p551
+
+BUNDLED WITH
+   1.14.3


### PR DESCRIPTION
The default Heroku version (>2.0) will fail to deploy.